### PR TITLE
Update .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -517,17 +517,26 @@ install_bashrc_support() {
 alias whatismyip="whatsmyip"
 function whatsmyip () {
     # Internal IP Lookup.
+	if command -v iw &> /dev/null; then
+	    # try to find correct wlan interface on system. Newer Ubuntu uses wlp
+	    DEV=$(iw dev | awk '/Interface/ {interf=$2} END {print interf}')
+	else
+	    #fail back to trying wlan0
+		DEV=wlan0
+	fi
+
     if command -v ip &> /dev/null; then
         echo -n "Internal IP: "
-        ip addr show wlan0 | grep "inet " | awk '{print $2}' | cut -d/ -f1
+        ip addr show $DEV | grep "inet " | awk '{print $2}' | cut -d/ -f1
     else
         echo -n "Internal IP: "
-        ifconfig wlan0 | grep "inet " | awk '{print $2}'
+        ifconfig $DEV | grep "inet " | awk '{print $2}'
     fi
 
     # External IP Lookup
     echo -n "External IP: "
     curl -s ifconfig.me
+	echo -e
 }
 
 # View Apache logs


### PR DESCRIPTION
Add support to correctly identify actual wlan interface name for whatsmyip function. Where wlan0 was hard coded we now try to identify actual device. On newer Ubuntu installs, the device is usually begins with wlp. If the iw command is not available, we fail back to hard coded wlan0. Also added a carriage return after the command to begin a new line.